### PR TITLE
simplify API by removing loads()/dumps()

### DIFF
--- a/demes/__init__.py
+++ b/demes/__init__.py
@@ -9,4 +9,4 @@ except ImportError:
     pass
 
 from .demes import Epoch, Migration, Pulse, Deme, Graph, Split, Branch, Merge, Admix
-from .load_dump import load_asdict, loads_asdict, load, loads, dump, dumps
+from .load_dump import load_asdict, load, dump

--- a/demes/convert/msprime_.py
+++ b/demes/convert/msprime_.py
@@ -312,7 +312,12 @@ def from_msprime(
                         dest=name[k],
                         start_time=ddb_epoch.end_time,
                         end_time=ddb_epoch.start_time,
-                        rate=msp_mm[j, k],
+                        # Explicitly convert to float, so we don't leak a
+                        # singleton numpy float type. This can be a problem
+                        # for annoying serialisers that want to look at the
+                        # type instead of happily outputting a number.
+                        # I'm looking at you, ruamel.yaml!
+                        rate=float(msp_mm[j, k]),
                     )
                     migrations[(j, k)].append(m)
                 else:

--- a/demes/convert/stdpopsim_.py
+++ b/demes/convert/stdpopsim_.py
@@ -69,8 +69,8 @@ if __name__ == "__main__":
     dm2 = to_stdpopsim(g)
     # dm2.get_demography_debugger().print_history()
     g2 = from_stdpopsim(dm2)
-    # print(demes.dumps(g2))
+    # demes.dump(g2, sys.stdout)
 
     assert g.isclose(g2)
 
-    print(demes.dumps(g))
+    demes.dump(g, sys.stdout, simplified=True)

--- a/demes/load_dump.py
+++ b/demes/load_dump.py
@@ -2,60 +2,35 @@
 Functions to load and dump graphs in YAML and JSON formats.
 """
 import json
-import copy
+import contextlib
 
 import ruamel.yaml
 
 import demes
 
 
-def _loads_yaml_asdict(string):
+@contextlib.contextmanager
+def _open_whatever(path_or_fileobj, mode="r"):
+    """
+    Open path_or_fileobj as a path and yield the fileobj. If that fails,
+    just yield path_or_fileobj under the assumption it's a fileobj.
+    """
+    try:
+        with open(path_or_fileobj, mode) as f:
+            yield f
+    except TypeError:
+        yield path_or_fileobj
+
+
+def _load_yaml_asdict(fp):
     with ruamel.yaml.YAML(typ="safe", pure=True) as yaml:
-        data = yaml.load(string)
-    # split comma separated fields
-    for deme in data.get("demes", []):
-        if "ancestors" in deme:
-            deme["ancestors"] = [anc.strip() for anc in deme["ancestors"].split(",")]
-        if "proportions" in deme:
-            deme["proportions"] = [float(p) for p in deme["proportions"].split(",")]
-    for mig in data.get("migrations", {}).get("symmetric", []):
-        mig["demes"] = [deme.strip() for deme in mig["demes"].split(",")]
-    return data
+        return yaml.load(fp)
 
 
-def _dumps_yaml_fromdict(data):
-    data = copy.deepcopy(data)
-    # collapse comma separated fields
-    for deme in data.get("demes", []):
-        if "ancestors" in deme:
-            deme["ancestors"] = ", ".join(deme["ancestors"])
-        if "proportions" in deme:
-            deme["proportions"] = ", ".join([str(p) for p in deme["proportions"]])
-    for mig in data.get("migrations", {}).get("symmetric", []):
-        mig["demes"] = ", ".join(mig["demes"])
-    string = ruamel.yaml.dump(data)
-    return string
-
-
-def loads_asdict(string, *, format="yaml"):
-    """
-    Load a YAML or JSON string into a dictionary of nested objects.
-    The keywords and structure of the string are defined by the
-    :ref:`schema <sec_schema>`.
-
-    :param str string: The string to be loaded.
-    :param str format: The format of the input string. Either "yaml" or "json".
-    :return: A dictionary of nested objects, with the same data model as the
-        YAML or JSON input string.
-    :rtype: dict
-    """
-    if format == "json":
-        data = json.loads(string)
-    elif format == "yaml":
-        data = _loads_yaml_asdict(string)
-    else:
-        raise ValueError(f"unknown format: {format}")
-    return data
+def _dump_yaml_fromdict(data, fp):
+    with ruamel.yaml.YAML(typ="safe", pure=True, output=fp) as yaml:
+        yaml.default_flow_style = False  # don't output json arrays/objects
+        yaml.dump(data)
 
 
 def load_asdict(filename, *, format="yaml"):
@@ -64,30 +39,23 @@ def load_asdict(filename, *, format="yaml"):
     The keywords and structure of the string are defined by the
     :ref:`schema <sec_schema>`.
 
-    :param filename: The path to the file to be loaded.
-    :type filename: str or :class:`os.PathLike`
+    :param filename: The path to the file to be loaded, or a file-like object
+        with a `read()` method.
+    :type filename: str or :class:`os.PathLike` or file object.
     :param str format: The format of the input string. Either "yaml" or "json".
     :return: A dictionary of nested objects, with the same data model as the
         YAML or JSON input string.
     :rtype: dict
     """
-    with open(filename) as f:
-        return loads_asdict(f.read(), format=format)
-
-
-def loads(string, *, format="yaml"):
-    """
-    Load a graph from a YAML or JSON string.
-    The keywords and structure of the string are defined by the
-    :ref:`schema <sec_schema>`.
-
-    :param str string: The string to be loaded.
-    :param str format: The format of the input string. Either "yaml" or "json".
-    :return: A graph.
-    :rtype: .Graph
-    """
-    data = loads_asdict(string, format=format)
-    return demes.Graph.fromdict(data)
+    if format == "json":
+        with _open_whatever(filename) as f:
+            data = json.load(f)
+    elif format == "yaml":
+        with _open_whatever(filename) as f:
+            data = _load_yaml_asdict(f)
+    else:
+        raise ValueError(f"unknown format: {format}")
+    return data
 
 
 def load(filename, *, format="yaml"):
@@ -96,42 +64,15 @@ def load(filename, *, format="yaml"):
     The keywords and structure of the file are defined by the
     :ref:`schema <sec_schema>`.
 
-    :param filename: The path to the file to be loaded.
-    :type filename: str or :class:`os.PathLike`
+    :param filename: The path to the file to be loaded, or a file-like object
+        with a `read()` method.
+    :type filename: str or :class:`os.PathLike` or file object.
     :param str format: The format of the input file. Either "yaml" or "json".
     :return: A graph.
     :rtype: .Graph
     """
     data = load_asdict(filename, format=format)
     return demes.Graph.fromdict(data)
-
-
-def dumps(graph, *, format="yaml", simplified=True):
-    """
-    Dump the specified graph to a YAML or JSON string.
-    The keywords and structure of the string are defined by the
-    :ref:`schema <sec_schema>`.
-
-    :param .Graph graph: The graph to dump.
-    :param str format: The format of the output file. Either "yaml" or "json".
-    :param bool simplified: If True, returns a simplified graph. If False, returns
-        a complete redundant graph.
-    :return: The YAML or JSON string.
-    :rtype: str
-    """
-    if simplified:
-        data = graph.asdict_simplified()
-    else:
-        data = graph.asdict()
-
-    if format == "json":
-        string = json.dumps(data)
-    elif format == "yaml":
-        string = _dumps_yaml_fromdict(data)
-    else:
-        raise ValueError(f"unknown format: {format}")
-
-    return string
 
 
 def dump(graph, filename, *, format="yaml", simplified=True):
@@ -141,11 +82,23 @@ def dump(graph, filename, *, format="yaml", simplified=True):
     :ref:`schema <sec_schema>`.
 
     :param .Graph graph: The graph to dump.
-    :param filename: Path to the output file.
-    :type filename: str or :class:`os.PathLike`
+    :param filename: Path to the output file, or a file-like object with a
+        `write()` method.
+    :type filename: str or :class:`os.PathLike` or file object.
     :param str format: The format of the output file. Either "yaml" or "json".
     :param bool simplified: If True, outputs a simplified graph. If False, outputs
         a redundant graph.
     """
-    with open(filename, "w") as f:
-        f.write(dumps(graph, format=format, simplified=simplified))
+    if simplified:
+        data = graph.asdict_simplified()
+    else:
+        data = graph.asdict()
+
+    if format == "json":
+        with _open_whatever(filename, "w") as f:
+            json.dump(data, f)
+    elif format == "yaml":
+        with _open_whatever(filename, "w") as f:
+            _dump_yaml_fromdict(data, f)
+    else:
+        raise ValueError(f"unknown format: {format}")

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -81,9 +81,7 @@ API Reference
 -------------
 
 .. autofunction:: demes.load
-.. autofunction:: demes.loads
 .. autofunction:: demes.dump
-.. autofunction:: demes.dumps
 
 .. autoclass:: demes.Graph
     :members:

--- a/examples/browning_america.yml
+++ b/examples/browning_america.yml
@@ -10,42 +10,42 @@ demes:
     initial_size: 7310
   - id: AMH
     description: Anatomically modern humans
-    ancestors: ancestral
+    ancestors: [ancestral]
     end_time: 2040
     initial_size: 14474
   - id: OOA
     description: Bottleneck out-of-Africa population
-    ancestors: AMH
+    ancestors: [AMH]
     end_time: 920
     initial_size: 1861
   - id: AFR
     description: African population
-    ancestors: AMH
+    ancestors: [AMH]
     initial_size: 14474
   - id: EUR
     description: European population
-    ancestors: OOA
+    ancestors: [OOA]
     initial_size: 1000
     final_size: 34039
   - id: EAS
     description: East Asian population
-    ancestors: OOA
+    ancestors: [OOA]
     initial_size: 510
     final_size: 45852
   - id: ADMIX
     description: Admixed America
-    ancestors: AFR, EUR, EAS
-    proportions: 0.167, 0.333, 0.5
+    ancestors: [AFR, EUR, EAS]
+    proportions: [0.167, 0.333, 0.5]
     start_time: 12
     initial_size: 30000
     final_size: 54664
 migrations:
   symmetric:
-  - demes: AFR, OOA
+  - demes: [AFR, OOA]
     rate: 15e-5
-  - demes: AFR, EUR
+  - demes: [AFR, EUR]
     rate: 2.5e-5
-  - demes: AFR, EAS
+  - demes: [AFR, EAS]
     rate: 0.78e-5
-  - demes: EUR, EAS
+  - demes: [EUR, EAS]
     rate: 3.11e-5

--- a/examples/cloning_example.yml
+++ b/examples/cloning_example.yml
@@ -10,7 +10,7 @@ demes:
     cloning_rate: 0.1
   - id: pop1
     description: Population with epochs and changing cloning rates
-    ancestors: root
+    ancestors: [root]
     cloning_rate: 0.2
     epochs:
     - initial_size: 1e4
@@ -22,7 +22,7 @@ demes:
       cloning_rate: 0.5
   - id: pop2
     description: Population with epochs and changing cloning rates
-    ancestors: root
+    ancestors: [root]
     epochs:
     - initial_size: 1e4
       end_time: 500

--- a/examples/gutenkunst_ooa.yml
+++ b/examples/gutenkunst_ooa.yml
@@ -15,35 +15,35 @@ demes:
     initial_size: 7300
   - id: AMH
     description: Anatomically modern humans
-    ancestors: ancestral
+    ancestors: [ancestral]
     end_time: 140e3
     initial_size: 12300
   - id: OOA
     description: Bottleneck out-of-Africa population
-    ancestors: AMH
+    ancestors: [AMH]
     end_time: 21.2e3
     initial_size: 2100
   - id: YRI
     description: Yoruba in Ibadan, Nigeria
-    ancestors: AMH
+    ancestors: [AMH]
     initial_size: 12300
   - id: CEU
     description: Utah Residents (CEPH) with Northern and Western European Ancestry
-    ancestors: OOA
+    ancestors: [OOA]
     initial_size: 1000
     final_size: 29725
   - id: CHB
     description: Han Chinese in Beijing, China
-    ancestors: OOA
+    ancestors: [OOA]
     initial_size: 510
     final_size: 54090
 migrations:
   symmetric:
-  - demes: YRI, OOA
+  - demes: [YRI, OOA]
     rate: 25e-5
-  - demes: YRI, CEU
+  - demes: [YRI, CEU]
     rate: 3e-5
-  - demes: YRI, CHB
+  - demes: [YRI, CHB]
     rate: 1.9e-5
-  - demes: CEU, CHB
+  - demes: [CEU, CHB]
     rate: 9.6e-5

--- a/examples/jacobs_papuans.yml
+++ b/examples/jacobs_papuans.yml
@@ -19,7 +19,7 @@ demes:
     - end_time: 0
       initial_size: 48433.0
   - id: DenA
-    ancestors: YRI
+    ancestors: [YRI]
     start_time: 20225.0
     epochs:
     - end_time: 15090.0
@@ -31,7 +31,7 @@ demes:
     - end_time: 0
       initial_size: 5083.0
   - id: NeaA
-    ancestors: DenA
+    ancestors: [DenA]
     start_time: 15090.0
     epochs:
     - end_time: 3375.0
@@ -39,19 +39,19 @@ demes:
     - end_time: 0
       initial_size: 826.0
   - id: Den2
-    ancestors: DenA
+    ancestors: [DenA]
     start_time: 12500.0
     initial_size: 13249.0
   - id: Den1
-    ancestors: DenA
+    ancestors: [DenA]
     start_time: 9750.0
     initial_size: 13249.0
   - id: Nea1
-    ancestors: NeaA
+    ancestors: [NeaA]
     start_time: 3375.0
     initial_size: 13249.0
   - id: Ghost
-    ancestors: YRI
+    ancestors: [YRI]
     start_time: 2218.0
     epochs:
     - end_time: 2119.0
@@ -59,7 +59,7 @@ demes:
     - end_time: 0
       initial_size: 8516.0
   - id: Papuan
-    ancestors: Ghost
+    ancestors: [Ghost]
     start_time: 1784.0
     epochs:
     - end_time: 1685.0
@@ -67,7 +67,7 @@ demes:
     - end_time: 0
       initial_size: 8834.0
   - id: CHB
-    ancestors: Ghost
+    ancestors: [Ghost]
     start_time: 1758.0
     epochs:
     - end_time: 1659.0
@@ -77,27 +77,27 @@ demes:
     - end_time: 0
       initial_size: 9025.0
   - id: CEU
-    ancestors: CHB
+    ancestors: [CHB]
     start_time: 1293.0
     initial_size: 6962.0
 migrations:
   symmetric:
-  - demes: YRI, Ghost
+  - demes: [YRI, Ghost]
     rate: 0.000179
     start_time: 1659.0
-  - demes: CHB, Papuan
+  - demes: [CHB, Papuan]
     rate: 0.000572
     start_time: 1659.0
     end_time: 1293.0
-  - demes: CHB, Papuan
+  - demes: [CHB, Papuan]
     rate: 5.72e-05
     start_time: 1293.0
-  - demes: CHB, Ghost
+  - demes: [CHB, Ghost]
     rate: 0.000442
     start_time: 1659.0
-  - demes: CEU, CHB
+  - demes: [CEU, CHB]
     rate: 3.14e-05
-  - demes: CEU, Ghost
+  - demes: [CEU, Ghost]
     rate: 0.000442
 pulses:
 - source: Nea1

--- a/examples/offshoots.yml
+++ b/examples/offshoots.yml
@@ -8,12 +8,12 @@ demes:
     initial_size: 1000
   - id: offshoot1
     description: More recent offshoot population
-    ancestors: ancestral
+    ancestors: [ancestral]
     start_time: 500
     initial_size: 100
   - id: offshoot2
     description: More ancient offshoot population
-    ancestors: ancestral
+    ancestors: [ancestral]
     start_time: 1000
     initial_size: 200
 migrations:
@@ -24,9 +24,9 @@ migrations:
     end_time: 100
     rate: 1e-4
   symmetric:
-  - demes: ancestral, offshoot2
+  - demes: [ancestral, offshoot2]
     rate: 1e-5
-  - demes: offshoot1, offshoot2
+  - demes: [offshoot1, offshoot2]
     rate: 2e-5
 pulses:
   - source: offshoot1

--- a/examples/selfing_example.yml
+++ b/examples/selfing_example.yml
@@ -10,7 +10,7 @@ demes:
     selfing_rate: 0.1
   - id: pop1
     description: Population with epochs and changing selfing rates
-    ancestors: root
+    ancestors: [root]
     selfing_rate: 0.2
     epochs:
     - initial_size: 1e4
@@ -22,7 +22,7 @@ demes:
       selfing_rate: 0.5
   - id: pop2
     description: Population with epochs and changing selfing rates
-    ancestors: root
+    ancestors: [root]
     epochs:
     - initial_size: 1e4
       end_time: 500

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -43,7 +43,16 @@ def yaml_strings(draw, min_size=1, max_size=100):
                     "Cs",  # surrogate block
                 ),
                 blacklist_characters=("\ufffe", "\uffff"),
-                whitelist_characters=("\x09", "\x0a", "\x0d", "\x85"),
+                whitelist_characters=(
+                    "\x09",
+                    "\x0a",
+                    "\x0d",
+                    # The \x85 'NEL' character gets converted to whitespace by
+                    # the ruamel YAML emmitter, which is probably sane. But it
+                    # means our graphs don't compare equal before/after dump/load.
+                    # So we exclude this character from the whitelist.
+                    # "\x85",
+                ),
             ),
             min_size=min_size,
             max_size=max_size,

--- a/tests/test_demes.py
+++ b/tests/test_demes.py
@@ -2,6 +2,7 @@ import unittest
 import copy
 import pathlib
 import json
+import tempfile
 
 import jsonschema
 import pytest
@@ -1228,7 +1229,10 @@ class TestGraph(unittest.TestCase):
         g2 = copy.deepcopy(g1)
         g1.deme("d1", initial_size=1000)
         self.assertTrue(g1.isclose(g1))
-        self.assertTrue(g1.isclose(demes.loads(demes.dumps(g1))))
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpfile = pathlib.Path(tmpdir) / "file.yml"
+            demes.dump(g1, tmpfile)
+            self.assertTrue(g1.isclose(demes.load(tmpfile)))
 
         # Don't care about description for equality.
         g3 = Graph(


### PR DESCRIPTION
It's not so common to need to load/dump from/to a string. But if you
really need to do it, e.g. we use this for tests, it's quite easy to
use a temporary file.
Moreover, we didn't have a way to load/dump from/to a file-like object
that has a write() method. This is far more useful, so we add that here.
This also provides another option for strings via io.StringIO().

Also closes #131 while in the neighbourhood.