### PR TITLE
use new ruamel API for dump()

### DIFF
--- a/demes/convert/msprime_.py
+++ b/demes/convert/msprime_.py
@@ -312,7 +312,12 @@ def from_msprime(
                         dest=name[k],
                         start_time=ddb_epoch.end_time,
                         end_time=ddb_epoch.start_time,
-                        rate=msp_mm[j, k],
+                        # Explicitly convert to float, so we don't leak a
+                        # singleton numpy float type. This can be a problem
+                        # for annoying serialisers that want to look at the
+                        # type instead of happily outputting a number.
+                        # I'm looking at you, ruamel.yaml!
+                        rate=float(msp_mm[j, k]),
                     )
                     migrations[(j, k)].append(m)
                 else:

--- a/demes/convert/stdpopsim_.py
+++ b/demes/convert/stdpopsim_.py
@@ -1,5 +1,3 @@
-import textwrap
-
 import stdpopsim
 
 import demes
@@ -50,7 +48,9 @@ def from_stdpopsim(demographic_model: stdpopsim.DemographicModel) -> demes.Graph
         pop_names=[pc.id for pc in demographic_model.populations],
     )
 
-    g.description = textwrap.dedent(demographic_model.long_description).strip()
+    g.description = " ".join(
+        s.strip() for s in demographic_model.long_description.splitlines() if s.strip()
+    )
     g.doi = [cite.doi for cite in demographic_model.citations]
     return g
 
@@ -72,5 +72,8 @@ if __name__ == "__main__":
     # print(demes.dumps(g2))
 
     assert g.isclose(g2)
+
+    g3 = demes.loads(demes.dumps(g))
+    assert g.isclose(g3)
 
     print(demes.dumps(g))


### PR DESCRIPTION
This avoids using the pyyaml-style dump(), which outputs truly
horrific YAML by default. The new API has its quirks though,
and we need to set some undocumented flags for it to behave.

Closes #155.

---
E.g. new output from `python demes/convert/stdpopsim_.py HomSap OutOfAfrica_3G09`. [EDIT: I found the undocumented flag to maintain dict-insertion-order sorting]

```yaml
description: The three population Out-of-Africa model from Gutenkunst et al. 2009.
  It describes the ancestral human population in Africa, the out of Africa event,
  and the subsequent European-Asian population split. Model parameters are the maximum
  likelihood values of the various parameters given in Table 1 of Gutenkunst et al.
time_units: generations
doi:
- https://doi.org/10.1371/journal.pgen.1000695
demes:
- id: YRI
  epochs:
  - end_time: 8800.0
    initial_size: 7300.0
  - end_time: 0
    initial_size: 12300.0
- id: CEU
  ancestors:
  - YRI
  epochs:
  - start_time: 5600.0
    end_time: 848.0
    initial_size: 2100.0
  - end_time: 0
    initial_size: 1000.0
    final_size: 29725.343546388514
- id: CHB
  ancestors:
  - CEU
  start_time: 848.0
  end_time: 0
  initial_size: 510.0
  final_size: 54090.331077946525
migrations:
  symmetric:
  - demes:
    - YRI
    - CEU
    rate: 0.00025
    end_time: 848.0
  - demes:
    - YRI
    - CEU
    rate: 3e-05
    start_time: 848.0
  - demes:
    - YRI
    - CHB
    rate: 1.9e-05
  - demes:
    - CEU
    - CHB
    rate: 9.6e-05
```