### PR TITLE
Simplified dict retains epochs

### DIFF
--- a/demes/demes.py
+++ b/demes/demes.py
@@ -1864,19 +1864,9 @@ class Graph:
                     if epoch["initial_size"] == epoch["final_size"]:
                         del epoch["final_size"]
 
-            # we don't specify the deme's start and end time, since it's included in the
-            # epoch information. in the case that a single epoch is specified in a deme
-            # we carry that information up to the deme level
             for deme in data["demes"]:
                 del deme["start_time"]
                 del deme["end_time"]
-                if (
-                    len(deme["epochs"]) == 1
-                    and "size_function" not in deme["epochs"][0]
-                ):
-                    deme.update(**deme["epochs"][0])
-                    del deme["epochs"]
-
                 if "ancestors" in deme and len(deme["ancestors"]) == 1:
                     del deme["proportions"]
 

--- a/tests/test_demes.py
+++ b/tests/test_demes.py
@@ -1752,7 +1752,7 @@ class TestGraphToDict(unittest.TestCase):
         d = dg.asdict()
         self.assertTrue(d["demes"][0]["epochs"][0]["cloning_rate"] == 0.1)
         d = dg.asdict_simplified()
-        self.assertTrue(d["demes"][0]["cloning_rate"] == 0.1)
+        self.assertTrue(d["demes"][0]["epochs"][0]["cloning_rate"] == 0.1)
         dg.deme("b", initial_size=200)
         d = dg.asdict_simplified()
         self.assertTrue("cloning_rate" not in d["demes"][1])


### PR DESCRIPTION
Previous behavior was that if a deme had a single epoch, start/end times and sizes were dropped down to the deme level. This retains all epochs instead.