### PR TITLE
Fix Zigzag population sizes.

### DIFF
--- a/examples/zigzag.yml
+++ b/examples/zigzag.yml
@@ -2,7 +2,7 @@ description: A single population model with epochs of exponential growth and dec
 doi:
   - https://doi.org/10.1038/ng.3015
 time_units: generations
-generation_time: 29
+generation_time: 30
 demes: 
   - id: generic
     description: All epochs wrapped into the same population, so that epoch intervals
@@ -10,22 +10,22 @@ demes:
       in this case).
     epochs:
     - end_time: 34133.31
-      start_size: 1431
+      start_size: 7156
     - start_time: 34133.31
       end_time: 8533.33
-      end_size: 14312
+      end_size: 71560
     - start_time: 8533.33
       end_time: 2133.33
-      end_size: 1431
+      end_size: 7156
     - start_time: 2133.33
       end_time: 533.33
-      end_size: 14312
+      end_size: 71560
     - start_time: 533.33
       end_time: 133.33
-      end_size: 1431
+      end_size: 7156
     - start_time: 133.33
       end_time: 33.333
-      end_size: 14312
+      end_size: 71560
     - start_time: 33.333
       end_time: 0
-      end_size: 14312
+      end_size: 71560


### PR DESCRIPTION
Also changes the (unused) generation time to match Schiffels & Durbin.

Closes #179.