### PR TITLE
Fix tests workflow to use numpy version in requirements.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,9 +44,21 @@ jobs:
 
       - name: install dependencies
         run: |
+          echo "## conda list"
+          conda list
           conda install --yes $(grep numpy requirements.txt) $(grep msprime requirements.txt)
+          echo "## conda list"
+          conda list
           pip install -r requirements.txt
+          echo "## conda list"
+          conda list
+          echo "## pip list"
+          pip list
 
       - name: run pytest
         run: |
+          echo "## conda list"
+          conda list
+          echo "## pip list"
+          pip list
           python -m pytest --cov=demes --cov-report=term-missing -v tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: install dependencies
         run: |
-          conda install --yes msprime==0.7.4
+          conda install --yes $(grep numpy requirements.txt) $(grep msprime requirements.txt)
           pip install -r requirements.txt
 
       - name: run pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,21 +44,15 @@ jobs:
 
       - name: install dependencies
         run: |
-          echo "## conda list"
-          conda list
           conda install --yes $(grep numpy requirements.txt) $(grep msprime requirements.txt)
-          echo "## conda list"
-          conda list
+          echo "## pip show numpy"
+          pip show numpy
           pip install -r requirements.txt
-          echo "## conda list"
-          conda list
-          echo "## pip list"
-          pip list
+          echo "## pip show numpy"
+          pip show numpy
 
       - name: run pytest
         run: |
-          echo "## conda list"
-          conda list
-          echo "## pip list"
-          pip list
+          echo "## pip show numpy"
+          pip show numpy
           python -m pytest --cov=demes --cov-report=term-missing -v tests


### PR DESCRIPTION
Msprime depends on numpy too, and the recent release of numpy 1.20.0 has
meant that 'conda install msprime' installs the latest numpy instead of
the version we have in requirements.txt. So this changes the 'conda install'
line in the tests workflow to also install numpy (with the correct version).