### PR TITLE
successors, predecessors, and discrete demographic events

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -112,3 +112,15 @@ API Reference
 
 .. autoclass:: demes.Pulse
     :members:
+
+.. autoclass:: demes.Split
+    :members:
+
+.. autoclass:: demes.Branch
+    :members:
+
+.. autoclass:: demes.Merge
+    :members:
+
+.. autoclass:: demes.Admix
+    :members:


### PR DESCRIPTION
* Successors and predecessors are now functions, rather than properties.
* list_demographic_events() has been renamed to discrete_demographic_events().
* Tests added for each of the above.
* Split, Branch, Merge, Admix added to docs/api.rst.

Closes #173 #170 #99.