### PR TITLE
Output YAML for the Graph __str__.

### DIFF
--- a/demes/demes.py
+++ b/demes/demes.py
@@ -8,6 +8,8 @@ import warnings
 
 import attr
 
+from .load_dump import dumps as demes_dumps
+
 Number = Union[int, float]
 Name = str
 Time = Number
@@ -1191,7 +1193,12 @@ class Graph:
     migrations: List[AsymmetricMigration] = attr.ib(factory=list, init=False)
     pulses: List[Pulse] = attr.ib(factory=list, init=False)
 
-    _deme_map: Dict[Name, Deme] = attr.ib(factory=dict, init=False)
+    # This attribute is for internal use only. It's a (hidden) attribute
+    # because we're using slotted classes and can't add attributes after
+    # object creation (e.g. in __attrs_post_init__()).
+    _deme_map: Dict[Name, Deme] = attr.ib(
+        factory=dict, init=False, repr=False, cmp=False
+    )
 
     def __attrs_post_init__(self):
         if self.time_units != "generations" and self.generation_time is None:
@@ -1210,6 +1217,9 @@ class Graph:
         Check if the graph contains a deme with the specified name.
         """
         return deme_name in self._deme_map
+
+    # Use the simplified YAML output as the string representation.
+    __str__ = demes_dumps
 
     def assert_close(
         self,

--- a/demes/load_dump.py
+++ b/demes/load_dump.py
@@ -41,8 +41,9 @@ def _load_yaml_asdict(fp):
 
 def _dump_yaml_fromdict(data, fp):
     with ruamel.yaml.YAML(typ="safe", output=fp) as yaml:
-        # Disable JSON-style inline arrays and dicts.
-        yaml.default_flow_style = False
+        # Output flow style, but only for collections that consist only
+        # of scalars (i.e. the leaves in the document tree).
+        yaml.default_flow_style = None
         # Don't emit obscure unicode, output "\Uxxxxxxxx" instead.
         # Needed for string equality after round-tripping.
         yaml.allow_unicode = False


### PR DESCRIPTION
Closes #235.
Closes #291.

Sample output:
```
$ python
Python 3.9.3 (default, Apr  8 2021, 23:35:02)
[GCC 10.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import demes
>>> demes.load("examples/gutenkunst_ooa.yml")
description: The Gutenkunst et al. (2009) OOA model.
time_units: years
generation_time: 25
doi: ['https://doi.org/10.1371/journal.pgen.1000695']
demes:
- name: ancestral
  description: Equilibrium/root population
  epochs:
  - {end_time: 220000.0, start_size: 7300}
- name: AMH
  description: Anatomically modern humans
  ancestors: [ancestral]
  epochs:
  - {end_time: 140000.0, start_size: 12300}
- name: OOA
  description: Bottleneck out-of-Africa population
  ancestors: [AMH]
  epochs:
  - {end_time: 21200.0, start_size: 2100}
- name: YRI
  description: Yoruba in Ibadan, Nigeria
  ancestors: [AMH]
  epochs:
  - {end_time: 0, start_size: 12300}
- name: CEU
  description: Utah Residents (CEPH) with Northern and Western European Ancestry
  ancestors: [OOA]
  epochs:
  - {end_time: 0, start_size: 1000, end_size: 29725}
- name: CHB
  description: Han Chinese in Beijing, China
  ancestors: [OOA]
  epochs:
  - {end_time: 0, start_size: 510, end_size: 54090}
migrations:
- demes: [YRI, CEU]
  rate: 3e-05
- demes: [YRI, CHB]
  rate: 1.9e-05
- demes: [CEU, CHB]
  rate: 9.6e-05
- {source: YRI, dest: OOA, rate: 0.00025}
- {source: OOA, dest: YRI, end_time: 21200.0, rate: 0.00025}

```