### PR TITLE
Add linear size function support

### DIFF
--- a/demes/demes.py
+++ b/demes/demes.py
@@ -163,8 +163,8 @@ class Epoch:
         If ``start_size != end_size``, the population size changes
         monotonically between the start and end times.
     :ivar str size_function: The size change function. This is either
-        ``constant`` or ``exponential``, though it is possible that
-        additional values will be added in the future.
+        ``constant``, ``exponential`` or ``linear``, though it is possible
+        that additional values will be added in the future.
 
          * ``constant``: the deme's size does not change over the epoch.
          * ``exponential``: the deme's size changes exponentially from
@@ -177,12 +177,15 @@ class Epoch:
                dt = (epoch.start_time - t) / epoch.time_span
                 r = math.log(epoch.end_size / epoch.start_size)
                 N = epoch.start_size * math.exp(r * dt)
+         * ``linear``: the deme's size changes linearly from
+           ``start_size`` to ``end_size`` over the epoch.
+           If :math:`t` is a time within the span of the epoch,
+           the deme size :math:`N` at :math:`t` can be calculated as:
 
-        .. warning::
+           .. code::
 
-            Do not assume an exponentially changing size just because
-            ``start_size != end_size``. For forwards compatibility,
-            applications should always check the ``size_function``.
+               dt = (epoch.start_time - t) / epoch.time_span
+                N = epoch.start_size + (epoch.end_size - epoch.start_size) * dt
 
     :ivar float selfing_rate: The selfing rate for this epoch.
     :ivar float cloning_rate: The cloning rate for this epoch.
@@ -193,7 +196,7 @@ class Epoch:
     start_size: Size = attr.ib(validator=[int_or_float, positive, finite])
     end_size: Size = attr.ib(validator=[int_or_float, positive, finite])
     size_function: str = attr.ib(
-        validator=attr.validators.in_(["constant", "exponential"])
+        validator=attr.validators.in_(["constant", "exponential", "linear"])
     )
     selfing_rate: Proportion = attr.ib(
         default=0, validator=[int_or_float, unit_interval]

--- a/examples/linear_size_function_example.yml
+++ b/examples/linear_size_function_example.yml
@@ -1,0 +1,27 @@
+description: Two-populations demography with linear size change.
+time_units: generations
+demes:
+- name: ancestral
+  description: An ancestral population that had linear growth.
+  epochs:
+    - start_size: 100
+      end_time: 2000
+    - start_size: 100
+      end_size: 1000
+      end_time: 1000
+      size_function: linear
+- name: pop_1
+  description: First population that had exponential growth
+  ancestors: [ancestral]
+  epochs:
+    - start_size: 500
+      end_size: 1000
+      end_time: 0
+- name: pop_2
+  description: Second population that had linear decrease after split.
+  ancestors: [ancestral]
+  epochs:
+    - start_size: 500
+      end_size: 10
+      end_time: 0
+      size_function: linear

--- a/tests/test_demes.py
+++ b/tests/test_demes.py
@@ -169,6 +169,20 @@ class TestEpoch(unittest.TestCase):
             end_size=100,
             size_function="exponential",
         )
+        Epoch(
+            start_time=100,
+            end_time=10,
+            start_size=1,
+            end_size=100,
+            size_function="linear",
+        )
+        Epoch(
+            start_time=20,
+            end_time=0,
+            start_size=100,
+            end_size=1,
+            size_function="linear",
+        )
         for rate in (0, 1, 0.5, 1e-5):
             Epoch(
                 start_time=math.inf,
@@ -222,6 +236,14 @@ class TestEpoch(unittest.TestCase):
                 start_size=10,
                 end_size=20,
                 size_function="exponential",
+            )
+        with self.assertRaises(ValueError):
+            Epoch(
+                start_time=math.inf,
+                end_time=0,
+                start_size=10,
+                end_size=20,
+                size_function="linear",
             )
 
     def test_isclose(self):


### PR DESCRIPTION
Solves issue #296.
I have add `linear` as available size function in `demes`. I am not sure about the order of size functions in doc strings and in lists: I have put `linear` at the end as it is less popular than `constant` and `exponential`.
I also have created new example .yml file for demography with several linear size changes in order to check load and dump in tests.