### PR TITLE
Add CLI.

### DIFF
--- a/demes/__main__.py
+++ b/demes/__main__.py
@@ -1,0 +1,135 @@
+import sys
+import functools
+
+import click
+import ruamel
+
+import demes
+
+
+@click.group()
+def main():
+    pass
+
+
+@main.command(context_settings={"ignore_unknown_options": True})
+@click.option("-N0", "N0", type=float, required=True, help="Reference population size")
+@click.argument("commands", required=True, nargs=-1)
+def ms(N0, commands):
+    """
+    Convert an ms command to a Demes model. E.g. (from the ms manual):
+
+        demes ms 15 1000 -t 6.4 -G 6.93 -eG 0.2 0.0 -eN 0.3 0.5 -N0 20000
+    """
+    graph = demes.from_ms(" ".join(commands), N0=N0)
+    demes.dump(graph, sys.stdout)
+
+
+def detect_input_format(input_format, filename):
+    if input_format is None:
+        if filename.endswith("json"):
+            input_format = "json"
+        else:
+            input_format = "yaml"
+    return input_format
+
+
+@main.command()
+@click.option(
+    "-f",
+    "--fully-resolved",
+    is_flag=True,
+    default=False,
+    help="Output fully-resolved model. A simplified model is output by default.",
+)
+@click.option("-i", "--input-format", type=click.Choice(["yaml", "json"]), default=None)
+@click.option(
+    "-o", "--output-format", type=click.Choice(["yaml", "json"]), default="yaml"
+)
+@click.argument("filename", type=str, default="-")
+def convert(fully_resolved: bool, input_format: str, output_format: str, filename):
+    """
+    Convert between JSON/YAML formats or simplified/fully-qualified variants.
+    """
+    input_format = detect_input_format(input_format, filename)
+    if filename == "-":
+        filename = sys.stdin
+    dump_func = functools.partial(demes.dump, format=output_format)
+    multidoc = False
+    try:
+        # Try single document loader.
+        graph_arg = demes.load(filename, format=input_format)
+    except ruamel.yaml.composer.ComposerError:
+        # ruamel complained about multiple documents
+        multidoc = True
+
+    if multidoc:
+        assert input_format == "yaml"
+        if output_format != "yaml":
+            print("multi-document files only supported with --output-format yaml")
+            exit(1)
+        graph_arg = demes.load_all(filename)
+        dump_func = demes.dump_all
+
+    dump_func(
+        graph_arg,
+        sys.stdout,
+        simplified=not fully_resolved,
+    )
+
+
+@main.command()
+@click.option("-i", "--input-format", type=click.Choice(["yaml", "json"]), default=None)
+@click.argument("filename", default="-")
+def validate(input_format: str, filename):
+    """
+    Validate a model.
+    """
+    input_format = detect_input_format(input_format, filename)
+    if filename == "-":
+        filename = sys.stdin
+
+    multidoc = False
+    try:
+        # Try single document loader.
+        demes.load(filename, format=input_format)
+    except ruamel.yaml.composer.ComposerError:
+        # ruamel complained about multiple documents
+        multidoc = True
+
+    if multidoc:
+        assert input_format == "yaml"
+        for _ in demes.load_all(filename):
+            pass
+
+
+@main.command()
+@click.option("-i", "--input-format", type=click.Choice(["yaml", "json"]), default=None)
+@click.option("-O", "--output-file", type=str, default=None)
+@click.argument("filename", default="-")
+def plot(input_format: str, output_file, filename):
+    """
+    Plot a model using the demesdraw library.
+    """
+    try:
+        import demesdraw
+    except ImportError:
+        print("must install demesdraw to use the plot subcommand")
+        exit(1)
+
+    input_format = detect_input_format(input_format, filename)
+    if filename == "-":
+        filename = sys.stdin
+    graph = demes.load(filename, format=input_format)
+    ax = demesdraw.tubes(graph)
+    if output_file is not None:
+        ax.figure.savefig(output_file)
+    else:
+        # interactive plot
+        import matplotlib.pyplot as plt
+
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/demes/load_dump.py
+++ b/demes/load_dump.py
@@ -240,7 +240,7 @@ def dump(graph, filename, *, format="yaml", simplified=True) -> None:
     if format == "json":
         with _open_file_polymorph(filename, "w") as f:
             _stringify_infinities(data)
-            json.dump(data, f, allow_nan=False)
+            json.dump(data, f, allow_nan=False, indent=2)
     elif format == "yaml":
         with _open_file_polymorph(filename, "w") as f:
             _dump_yaml_fromdict(data, f)

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,10 @@ setup_requires =
     setuptools
     setuptools_scm
 
+[options.entry_points]
+￼console_scripts =
+￼    demes = demes.__main__:main
+
 [flake8]
 extend-exclude = docs/_build
 # black-compatible settings


### PR DESCRIPTION
This PR isn't what I expect to be merged, I'm just posting to solicit feedback.

1. I've implemented this using `click`. It seems ok. But I'm not sure about having the extra dependency. At least click itself has no additional dependencies.
2. If we have a "convert" subcommand, do we really need/want "validate" as well? One might just as easily use the "convert" subcommand and redirect to /dev/null.
3. I included a "plot" subcommand to facilitate easy plotting with demesdraw. I expect to remove this before merging, and put a more featurful CLI to demesdraw itself.
4. When we have a `to_ms()` function, should we add a "to_ms" subcommand, or add "ms" as an output format for the "convert" subcommand? Do you think other conversion functions will naturally slot in here?
5. Is the structure of the commands/subcommands ok?

Some examples:
```
$ python -m demes
Usage: python -m demes [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  convert   Convert between JSON/YAML formats or...
  ms        Convert an ms command to a Demes model.
  plot      Plot a model using the demesdraw library.
  validate  Validate a model.
```
```
$ python -m demes ms --help
Usage: python -m demes ms [OPTIONS] COMMANDS...

  Convert an ms command to a Demes model. E.g. (from the ms manual):

      demes ms 15 1000 -t 6.4 -G 6.93 -eG 0.2 0.0 -eN 0.3 0.5 -N0 20000

Options:
  -N0 FLOAT  Reference population size  [required]
  --help     Show this message and exit.
```
```
$ python -m demes ms 15 1000 -t 6.4 -G 6.93 -eG 0.2 0.0 -eN 0.3 0.5 -N0 20000 | python -m demes validate
Ignoring unknown args: ['15', '1000', '-t', '6.4']
```
```
$ python -m demes ms -G 6.93 -eG 0.2 0.0 -eN 0.3 0.5 -N0 20000
time_units: generations
demes:
- name: deme1
  epochs:
  - {end_time: 24000.0, start_size: 10000.0}
  - {end_time: 16000.0, start_size: 5001.472022241883}
  - {end_time: 0, start_size: 5001.472022241883, end_size: 20000.0}
```
```
$ python -m demes ms -G 6.93 -eG 0.2 0.0 -eN 0.3 0.5 -N0 20000 | python -m demes convert -f
time_units: generations
demes:
- name: deme1
  start_time: .inf
  epochs:
  - {end_time: 24000.0, start_size: 10000.0, end_size: 10000.0, size_function: constant,
    selfing_rate: 0, cloning_rate: 0}
  - {end_time: 16000.0, start_size: 5001.472022241883, end_size: 5001.472022241883,
    size_function: constant, selfing_rate: 0, cloning_rate: 0}
  - {end_time: 0, start_size: 5001.472022241883, end_size: 20000.0, size_function: exponential,
    selfing_rate: 0, cloning_rate: 0}
```
```
$ python -m demes ms -G 6.93 -eG 0.2 0.0 -eN 0.3 0.5 -N0 20000 | python -m demes convert -o json
{
  "time_units": "generations",
  "demes": [
    {
      "name": "deme1",
      "epochs": [
        {
          "end_time": 24000.0,
          "start_size": 10000.0
        },
        {
          "end_time": 16000.0,
          "start_size": 5001.472022241883
        },
        {
          "end_time": 0,
          "start_size": 5001.472022241883,
          "end_size": 20000.0
        }
      ]
    }
  ]
}
```
```
$ python -m demes ms -G 6.93 -eG 0.2 0.0 -eN 0.3 0.5 -N0 20000 | python -m demes plot -O /tmp/ms-example.png
```
![ms-example](https://user-images.githubusercontent.com/8665077/123434495-d5af1d00-d5cc-11eb-9108-f19ffff38230.png)
