### PR TITLE
Add CLI (argparse version).

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,13 @@ jobs:
           pip install -r requirements/minimal.txt
           pip install -r requirements/tests.txt
 
+      # Check that demes installs as expected.
+      # Also check the "demes" CLI entry point.
+      - name: install demes
+        run: |
+          pip install .
+          demes -h
+
       - name: run pytest
         run: |
           python -m pytest -n auto \

--- a/demes/__main__.py
+++ b/demes/__main__.py
@@ -1,0 +1,187 @@
+import io
+import sys
+import itertools
+import argparse
+from typing import Iterator, Tuple, Union
+import textwrap
+
+import demes
+from . import ms
+
+
+class ParseCommand:
+    """
+    Parse models and write them to stdout in canonical form.
+    """
+
+    def __init__(self, subparsers):
+        parser = subparsers.add_parser(
+            "parse",
+            help=self.__doc__,
+            description=textwrap.dedent(self.__doc__),
+        )
+        parser.set_defaults(func=self)
+        parser.add_argument(
+            "-j",
+            "--json",
+            action="store_true",
+            default=False,
+            help="Output a JSON-formatted model. YAML is output by default.",
+        )
+        parser.add_argument(
+            "-s",
+            "--simplified",
+            action="store_true",
+            default=False,
+            help=(
+                "Output a simplified model. This is a compact representation "
+                "in which many default values are ommited. As only the "
+                "essential details are retained, this is usually easier for "
+                "humans to read. The simplfied output is guaranteed to be a "
+                "valid Demes model that can be resolved identically to the "
+                "input model. But exactly which fields are simplfied, "
+                "and how simplification is performed, may change over time. "
+                "Thus users should not rely on details of the output such as "
+                "presence or absense of specific fields, or other details "
+                "that do not alter how the model is resolved into a "
+                "fully-qualified model. "
+                "A fully-qualified model is output by default."
+            ),
+        )
+        parser.add_argument(
+            "filename",
+            type=argparse.FileType(),
+            help=(
+                "Filename of the model. The special value '-' may be used to "
+                "read from stdin. The file may be in YAML or JSON format, "
+                "but will be parsed as YAML. Multi-document YAML is supported."
+            ),
+        )
+
+    def __call__(self, args: argparse.Namespace) -> None:
+        if args.json:
+            output_format = "json"
+        else:
+            output_format = "yaml"
+
+        num_documents, graphs = self.load_and_count_documents(args.filename)
+        if num_documents == 0:
+            # Input file is empty.
+            pass
+        elif num_documents == 1:
+            demes.dump(
+                next(graphs),
+                sys.stdout,
+                simplified=args.simplified,
+                format=output_format,
+            )
+        else:
+            if output_format != "yaml":
+                raise RuntimeError(
+                    "The input file contains multiple models, which is only "
+                    "supported with YAML output. If multi-model JSON output "
+                    "would be useful to you, please open an issue on github.",
+                )
+            demes.dump_all(graphs, sys.stdout, simplified=args.simplified)
+
+    def load_and_count_documents(
+        self, filename: Union[str, io.TextIOBase]
+    ) -> Tuple[int, Iterator[demes.Graph]]:
+        """
+        Count the documents in the file, returning the count and an iterator
+        over the graphs. The returned document count is:
+            0 for zero documents,
+            1 for one document, and
+            2 for two or more documents.
+        """
+        graph_generator = demes.load_all(filename)
+        graph_list = []
+        # See if we get at least two graphs. If there are more than two,
+        # they'll still be lazily loaded as needed by the caller.
+        for graph in graph_generator:
+            graph_list.append(graph)
+            if len(graph_list) > 1:
+                break
+        num_documents = len(graph_list)
+        graph_iter = itertools.chain(graph_list, graph_generator)
+        return num_documents, graph_iter
+
+
+class MsCommand:
+    """
+    Build a Demes model from commands accepted by Hudson's classic ms simulator.
+    https://doi.org/10.1093/bioinformatics/18.2.337
+
+    Ms commands correspond to a backwards-time model of population dynamics,
+    and use coalescent units for times t, population sizes x, and migration
+    rates m. These are converted to more familiar units using the reference
+    size N0 according to the following rules:
+
+     - time (in generations) = 4 * N0 * t,
+     - deme size (haploid individuals) = N0 * x,
+     - migration rate (per generation) = m / (4 * N0).
+
+    Deme IDs are 1-based, and migration matrix entry M[i, j] is the
+    forwards-time fraction of deme i which is made up of migrants from
+    deme j each generation.
+
+    Please refer to the ms manual for the precise semantics of each command.
+    http://home.uchicago.edu/~rhudson1/source/mksamples.html
+    """
+
+    def __init__(self, subparsers):
+        parser = subparsers.add_parser(
+            "ms",
+            help="Build a Demes model using ms commands.",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=textwrap.dedent(self.__doc__),
+        )
+        parser.set_defaults(func=self)
+
+        required_group = parser.add_argument_group(
+            title="required arguments", description=None
+        )
+        required_group.add_argument(
+            "-N0",
+            "--reference-size",
+            type=float,
+            required=True,
+            help=(
+                "The reference population size used to translate from coalescent "
+                "units. For an existing ms command, this can be calculated as "
+                "theta / (4 * mu * L), "
+                "where theta is the value given to the -t option, "
+                "mu is the per-generation mutation rate, "
+                "and L is the length of the sequence being simulated."
+            ),
+        )
+        ms_group = parser.add_argument_group(title="ms arguments", description=None)
+        ms.build_parser(ms_group)
+
+    def __call__(self, args: argparse.Namespace) -> None:
+        graph = ms.build_graph(args, N0=args.reference_size)
+        demes.dump(graph, sys.stdout)
+
+
+def get_demes_parser() -> argparse.ArgumentParser:
+    top_parser = argparse.ArgumentParser(
+        prog="demes", description="Demes model parser and converter."
+    )
+    top_parser.add_argument("--version", action="version", version=demes.__version__)
+    subparsers = top_parser.add_subparsers(dest="subcommand")
+    ParseCommand(subparsers)
+    MsCommand(subparsers)
+    return top_parser
+
+
+def cli(args_list=None) -> None:
+    top_parser = get_demes_parser()
+    args = top_parser.parse_args(args_list)
+    if args.subcommand is None:
+        top_parser.print_help()
+        exit(1)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    cli()

--- a/demes/load_dump.py
+++ b/demes/load_dump.py
@@ -139,12 +139,15 @@ def load_asdict(filename, *, format="yaml") -> MutableMapping[str, Any]:
     if format == "json":
         with _open_file_polymorph(filename) as f:
             data = json.load(f)
-            _unstringify_infinities(data)
     elif format == "yaml":
         with _open_file_polymorph(filename) as f:
             data = _load_yaml_asdict(f)
     else:
         raise ValueError(f"unknown format: {format}")
+    # The string "Infinity" should only be present in JSON files.
+    # But YAML is a superset of JSON, so we want the YAML loader to also
+    # load JSON files without problem.
+    _unstringify_infinities(data)
     return data
 
 
@@ -240,7 +243,7 @@ def dump(graph, filename, *, format="yaml", simplified=True) -> None:
     if format == "json":
         with _open_file_polymorph(filename, "w") as f:
             _stringify_infinities(data)
-            json.dump(data, f, allow_nan=False)
+            json.dump(data, f, allow_nan=False, indent=2)
     elif format == "yaml":
         with _open_file_polymorph(filename, "w") as f:
             _dump_yaml_fromdict(data, f)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,6 +35,7 @@ sphinx:
     - sphinx.ext.viewcode
     - sphinx.ext.intersphinx
     - sphinx_issues
+    - sphinxcontrib.programoutput
 
     config:
       issues_github_path: popsim-consortium/demes-python

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -2,5 +2,6 @@
 - file: installation
 - file: quickstart
 - file: api
+- file: cli
 - file: development
 - file: changelog

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,15 @@
+
+# Command line interface
+
+```{program-output} python -m demes -h
+```
+
+## demes parse
+
+```{program-output} python -m demes parse -h
+```
+
+## demes ms
+
+```{program-output} python -m demes ms -h
+```

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,4 @@
 jupyter-book==0.10.2
 sphinx==3.5.4
 sphinx_issues==1.2.0
+sphinxcontrib-programoutput==0.17

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,10 @@ setup_requires =
     setuptools
     setuptools_scm
 
+[options.entry_points]
+console_scripts =
+    demes = demes.__main__:cli
+
 [flake8]
 extend-exclude = docs/_build
 # black-compatible settings

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,162 @@
+import subprocess
+import tempfile
+import pathlib
+import filecmp
+import gc
+
+import pytest
+
+import demes
+from demes.__main__ import cli
+
+
+class TestTopLevel:
+    def test_help(self):
+        out1 = subprocess.run(
+            "python -m demes -h".split(), check=True, stdout=subprocess.PIPE
+        )
+        out2 = subprocess.run(
+            "python -m demes --help".split(), check=True, stdout=subprocess.PIPE
+        )
+        assert out1.stdout == out2.stdout
+
+    def test_no_arguments_produces_help_output(self):
+        # If no params are given, the output is the same as --help.
+        # But the returncode should be non-zero.
+        out1 = subprocess.run("python -m demes -h".split(), stdout=subprocess.PIPE)
+        out2 = subprocess.run("python -m demes".split(), stdout=subprocess.PIPE)
+        assert out1.stdout == out2.stdout
+        assert out2.returncode != 0
+
+    def test_version(self):
+        out = subprocess.run(
+            "python -m demes --version".split(),
+            stdout=subprocess.PIPE,
+            encoding="utf8",
+        )
+        assert out.stdout.strip() == demes.__version__
+
+
+class TestMsCommand:
+    def test_help(self):
+        out1 = subprocess.run(
+            "python -m demes ms -h".split(), check=True, stdout=subprocess.PIPE
+        )
+        out2 = subprocess.run(
+            "python -m demes ms --help".split(), check=True, stdout=subprocess.PIPE
+        )
+        assert out1.stdout == out2.stdout
+
+    def test_basic(self):
+        b = demes.Builder()
+        b.add_deme("deme1", epochs=[dict(start_size=1)])
+        graph1 = b.resolve()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpfile = pathlib.Path(tmpdir) / "model.yaml"
+            with open(tmpfile, "w") as f:
+                subprocess.run("python -m demes ms -N0 1".split(), check=True, stdout=f)
+            graph2 = demes.load(tmpfile)
+        graph1.assert_close(graph2)
+
+    def test_msdoc_example3(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpfile = pathlib.Path(tmpdir) / "model.yaml"
+            with open(tmpfile, "w") as f:
+                subprocess.run(
+                    (
+                        "python -m demes "
+                        "ms -N0 20000 -G 6.93 -eG 0.2 0.0 -eN 0.3 0.5"
+                    ).split(),
+                    check=True,
+                    stdout=f,
+                )
+            graph = demes.load(tmpfile)
+        assert len(graph.migrations) == 0
+        assert len(graph.pulses) == 0
+        assert len(graph.demes) == 1
+        assert len(graph.demes[0].epochs) == 3
+
+
+class TestParseCommand:
+    def test_help(self):
+        out1 = subprocess.run(
+            "python -m demes parse -h".split(), check=True, stdout=subprocess.PIPE
+        )
+        out2 = subprocess.run(
+            "python -m demes parse --help".split(), check=True, stdout=subprocess.PIPE
+        )
+        assert out1.stdout == out2.stdout
+
+    def test_empty_file(self):
+        # An empty file should produce no output.
+        out1 = subprocess.run(
+            "python -m demes parse -".split(),
+            check=True,
+            stdout=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+        )
+        assert out1.stdout == b""
+
+    @pytest.mark.parametrize("input_format", ["json", "yaml"])
+    @pytest.mark.parametrize("output_format", ["json", "yaml"])
+    @pytest.mark.parametrize("simplified", [True, False])
+    def test_one_graph(self, simplified, input_format, output_format):
+        b = demes.Builder()
+        b.add_deme("A", epochs=[dict(start_size=100)])
+        graph1 = b.resolve()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpfile1 = pathlib.Path(tmpdir) / "model1.yaml"
+            tmpfile2 = pathlib.Path(tmpdir) / "model2.yaml"
+            demes.dump(graph1, tmpfile1, format=input_format)
+            with open(tmpfile2, "w") as f:
+                stxt = "-s" if simplified else ""
+                jtxt = "-j" if output_format == "json" else ""
+                subprocess.run(
+                    f"python -m demes parse {stxt} {jtxt} {tmpfile1}".split(),
+                    check=True,
+                    stdout=f,
+                )
+            graph2 = demes.load(tmpfile2, format=output_format)
+            graph1.assert_close(graph2)
+
+            demes.dump(graph1, tmpfile1, simplified=simplified, format=output_format)
+            assert filecmp.cmp(tmpfile1, tmpfile2)
+
+    @pytest.mark.parametrize("simplified", [True, False])
+    def test_multiple_graphs(self, simplified):
+        b = demes.Builder()
+        b.add_deme("A", epochs=[dict(start_size=100)])
+        graphs = [b.resolve()]
+        b.add_deme("B", epochs=[dict(start_size=100)])
+        graphs.append(b.resolve())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpfile1 = pathlib.Path(tmpdir) / "multidoc1.yaml"
+            tmpfile2 = pathlib.Path(tmpdir) / "multidoc2.yaml"
+            demes.dump_all(graphs, tmpfile1)
+            with open(tmpfile2, "w") as f:
+                stxt = "-s" if simplified else ""
+                subprocess.run(
+                    f"python -m demes parse {stxt} {tmpfile1}".split(),
+                    check=True,
+                    stdout=f,
+                )
+            g1, g2 = demes.load_all(tmpfile2)
+            g1.assert_close(graphs[0])
+            g2.assert_close(graphs[1])
+
+            demes.dump_all(graphs, tmpfile1, simplified=simplified)
+            assert filecmp.cmp(tmpfile1, tmpfile2)
+
+    def test_json_output_with_multiple_graphs_error(self):
+        b = demes.Builder()
+        b.add_deme("A", epochs=[dict(start_size=100)])
+        graphs = [b.resolve()]
+        b.add_deme("B", epochs=[dict(start_size=100)])
+        graphs.append(b.resolve())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpfile1 = pathlib.Path(tmpdir) / "multidoc1.yaml"
+            demes.dump_all(graphs, tmpfile1)
+            with pytest.raises(RuntimeError):
+                cli(f"parse -j {tmpfile1}".split())
+            # Release tmpfile1. Needed on Windows for some reason.
+            gc.collect()

--- a/tests/test_ms.py
+++ b/tests/test_ms.py
@@ -1119,18 +1119,22 @@ class TestFromMs:
                 demes.from_ms("-I 2 1 1", N0=1, deme_names=bad_deme_names)
 
     def test_unhandled_event(self):
-        from demes.ms import parse_ms_args, build_graph
+        from demes.ms import build_parser, build_graph
+
+        parser = build_parser()
 
         class Foo:
             t: float
 
         foo = Foo()
         foo.t = 0
-        args, _ = parse_ms_args("-I 2 1 1")
+        args = parser.parse_args("-I 2 1 1".split())
         args.initial_state.append(foo)
         with pytest.raises(AssertionError):
             build_graph(args, 1)
 
         foo.t = 1.0
-        args, _ = parse_ms_args("-I 2 1 1")
-        args.initial_state.append(foo)
+        args = parser.parse_args("-I 2 1 1".split())
+        args.demographic_events.append(foo)
+        with pytest.raises(AssertionError):
+            build_graph(args, 1)


### PR DESCRIPTION
There are a few differences here compared with #338. In particular, the `ms` subcommand is a first class citizen with proper help output (reusing the existing ms parser argparse code, which is somewhere between complicated and impossible when using click). I don't have a strong opinion on what the "validate" subcommand is called, or how the options are spelled, but I think the options/defaults in this PR strike better balance than #338.

```
$ python -m demes -h
usage: __main__.py [-h] {validate,ms} ...

Validate and convert Demes models

positional arguments:
  {validate,ms}
    validate     Validate a model.
    ms           Build a demes model using ms commands.

optional arguments:
  -h, --help     show this help message and exit
```

```
$ python -m demes validate -h
usage: __main__.py validate [-h] [-j] [-s] [filename]

positional arguments:
  filename          Filename of the model. If not specified, the model will be read
                    from stdin.

optional arguments:
  -h, --help        show this help message and exit
  -j, --json        Output a JSON-formatted model. YAML is output by default.
  -s, --simplified  Output simplified model.
```

```
$ python -m demes ms -h
usage: __main__.py ms [-h] -N0 REFERENCE_SIZE [-f FILENAME] [-I value [value ...]]
                      [-n i x] [-g i α] [-G α] [-m i j rate] [-ma entry [entry ...]]
                      [-eG t α] [-eg t i α] [-eN t x] [-en t i x] [-eM t x]
                      [-em t i j rate] [-ema entry [entry ...]] [-es t i p]
                      [-ej t i j]

optional arguments:
  -h, --help            show this help message and exit
  -N0 REFERENCE_SIZE, --reference-size REFERENCE_SIZE
                        The reference population size used to translate from
                        coalescent units. This can be calculated from an existing ms
                        command as N0 = theta / (4 * μ * L), where μ is the per-
                        generation mutation rate and L is the length of the sequence
                        being simulated.
  -f FILENAME, --filename FILENAME
                        Insert commands from a file at this point in the command
                        line.
  -I value [value ...], --structure value [value ...]
                        Sample from populations with the specified deme structure.
                        The arguments are of the form 'num_demes n1 n2 ... [4N0m]',
                        specifying the number of populations, the sample
                        configuration, and optionally, the migration rate for a
                        symmetric island model
  -n i x, --population-size i x
                        Set the size of a specific population to x * N0.
  -g i α, --population-growth-rate i α
                        Set the growth rate to α for a specific population.
  -G α, --growth-rate α
                        Set the growth rate to α for all populations.
  -m i j rate, --migration-matrix-entry i j rate
                        Sets an entry M[i, j] in the migration matrix to the
                        specified rate. i and j are (1-indexed) population IDs.
                        Multiple options can be specified.
  -ma entry [entry ...], --migration-matrix entry [entry ...]
                        Sets the migration matrix to the specified value. The
                        entries are in the order M[1, 1], M[1, 2], ..., M[2, 1],
                        M[2, 2], ..., M[N, N], where N is the number of populations.
                        Diagonal entries may be written as 'x'.
  -eG t α, --growth-rate-change t α
                        Set the growth rate for all populations to α at time t
  -eg t i α, --population-growth-rate-change t i α
                        Set the growth rate for population i to α at time t
  -eN t x, --size-change t x
                        Set the population size for all populations to x * N0 at
                        time t
  -en t i x, --population-size-change t i x
                        Set the population size for population i to x * N0 at time t
  -eM t x, --migration-rate-change t x
                        Set the symmetric island model migration rate to x / (npop -
                        1) at time t
  -em t i j rate, --migration-matrix-entry-change t i j rate
                        Sets an entry M[i, j] in the migration matrix to the
                        specified rate at the specified time. i and j are
                        (1-indexed) population IDs.
  -ema entry [entry ...], --migration-matrix-change entry [entry ...]
                        Sets the migration matrix to the specified value at time t.
                        The entries are in the order M[1, 1], M[1, 2], ..., M[2, 1],
                        M[2, 2], ..., M[N, N], where N is the number of populations.
                        Diagonal entries may be written as 'x'.
  -es t i p, --admixture t i p
                        Split population i into a new population, such that the
                        specified proportion p of lineages remains in the population
                        i. Forwards in time this corresponds to an admixture event.
                        The new population has ID num_demes + 1. Migration rates to
                        and from the new population are set to 0, and growth rate is
                        0 and the population size for the new population is N0.
  -ej t i j, --population-split t i j
                        Move all lineages in population i to j at time t. Forwards
                        in time, this corresponds to a population split in which
                        lineages in j split into i. All migration rates for
                        population i are set to zero.
```

```
$ python -m demes ms -G 6.93 -eG 0.2 0.0 -eN 0.3 0.5 -N0 20000 | python -m demes validate -j
{
  "time_units": "generations",
  "demes": [
    {
      "name": "deme1",
      "start_time": "Infinity",
      "epochs": [
        {
          "end_time": 24000.0,
          "start_size": 10000.0,
          "end_size": 10000.0,
          "size_function": "constant",
          "selfing_rate": 0,
          "cloning_rate": 0
        },
        {
          "end_time": 16000.0,
          "start_size": 5001.472022241883,
          "end_size": 5001.472022241883,
          "size_function": "constant",
          "selfing_rate": 0,
          "cloning_rate": 0
        },
        {
          "end_time": 0,
          "start_size": 5001.472022241883,
          "end_size": 20000.0,
          "size_function": "exponential",
          "selfing_rate": 0,
          "cloning_rate": 0
        }
      ]
    }
  ]
}
```