### PR TITLE
Closes #358

### DIFF
--- a/demes/demes.py
+++ b/demes/demes.py
@@ -2373,6 +2373,8 @@ class Builder:
         if proportions is not None:
             deme["proportions"] = proportions
         if start_time is not None:
+            if start_time == "Infinity":
+                start_time = math.inf
             deme["start_time"] = start_time
         if epochs is not None:
             deme["epochs"] = epochs
@@ -2427,6 +2429,8 @@ class Builder:
         if dest is not NO_DEFAULT:
             migration["dest"] = dest
         if start_time is not None:
+            if start_time == "Infinity":
+                start_time = math.inf
             migration["start_time"] = start_time
         if end_time is not None:
             migration["end_time"] = end_time

--- a/demes/load_dump.py
+++ b/demes/load_dump.py
@@ -104,6 +104,11 @@ def _unstringify_infinities(data: MutableMapping[str, Any]) -> None:
         start_time = migration.get("start_time")
         if start_time == _INFINITY_STR:
             migration["start_time"] = float(start_time)
+    for default in data.get("defaults", []):
+        if default in ["migration", "deme"]:
+            start_time = data["defaults"][default].get("start_time")
+            if start_time == _INFINITY_STR:
+                data["defaults"][default]["start_time"] = float(start_time)
 
 
 def loads_asdict(string, *, format="yaml") -> MutableMapping[str, Any]:


### PR DESCRIPTION
~~Check if "Infinity" is given as a start time, which is converted to `math.inf` in `Builder.add_deme()`. Maybe there is a more appropriate place to handle this?~~ What do you think, @grahamgower 

~~Edit: uses `load_dump._unstringify_infinities()` in `Builder.resolve()`.~~

Edit 2: simply adjust a deme or migration start time in `add_deme()` and `add_migration()`. Using `_unstringify_infinities()` causes some complications where `fromdict()` in `Builder.resolve()` is not able to catch type errors.