### PR TITLE
Don't yield in an exception handler.

### DIFF
--- a/demes/load_dump.py
+++ b/demes/load_dump.py
@@ -19,10 +19,14 @@ def _open_file_polymorph(polymorph, mode="r"):
     just yield polymorph under the assumption it's a fileobj.
     """
     try:
-        with open(polymorph, mode) as f:
-            yield f
+        f = open(polymorph, mode)
     except TypeError:
-        yield polymorph
+        f = polymorph
+    try:
+        yield f
+    finally:
+        if f is not polymorph:
+            f.close()
 
 
 # NOTE: The state of Python YAML libraries in 2020 leaves much to be desired.

--- a/tests/test_load_dump.py
+++ b/tests/test_load_dump.py
@@ -3,6 +3,7 @@ import decimal
 import enum
 import fractions
 import json
+import os
 import pathlib
 import tempfile
 import textwrap
@@ -773,3 +774,37 @@ class TestMultiDocument:
             assert tmpfile.stat().st_size == 0
             graphs = list(demes.load_all(tmpfile))
             assert len(graphs) == 0
+
+
+class TestOpenFilePolymorph:
+    def test_fileobj_doesnt_get_closed_1(self):
+        devnull = open(os.devnull)
+        with demes.load_dump._open_file_polymorph(devnull, "w") as f:
+            pass
+        assert not f.closed
+        assert not devnull.closed
+        devnull.close()
+
+    def test_fileobj_doesnt_get_closed_2(self):
+        devnull = open(os.devnull)
+        try:
+            with demes.load_dump._open_file_polymorph(devnull, "w") as f:
+                raise ValueError
+        except ValueError:
+            pass
+        assert not f.closed
+        assert not devnull.closed
+        devnull.close()
+
+    def test_no_file_descriptor_leak_1(self):
+        with demes.load_dump._open_file_polymorph(os.devnull, "w") as f:
+            pass
+        assert f.closed
+
+    def test_no_file_descriptor_leak_2(self):
+        try:
+            with demes.load_dump._open_file_polymorph(os.devnull, "w") as f:
+                raise ValueError
+        except ValueError:
+            pass
+        assert f.closed


### PR DESCRIPTION
This is a flow-control exception rather than an error condition,
and when it appears in backtraces it can be confusing.

---

Compare the error from this yaml file:
```yaml
# p.yaml
time_units: generations
demes:
- name: a
  epochs:
  - start_size: 1
- name: b
  epochs:
  - start_size: 1
pulses:
- {source: a, dest: b, time: 100, proportion: 0.1}
```

Before this commit:

```
$ demes parse p.yaml
Traceback (most recent call last):
  File "/home/grg/.local/lib/python3.9/site-packages/demes/load_dump.py", line 22, in _open_file_polymorph
    with open(polymorph, mode) as f:
TypeError: expected str, bytes or os.PathLike object, not TextIOWrapper

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/grg/.local/bin/demes", line 8, in <module>
    sys.exit(cli())
  File "/home/grg/.local/lib/python3.9/site-packages/demes/__main__.py", line 212, in cli
    args.func(args)
  File "/home/grg/.local/lib/python3.9/site-packages/demes/__main__.py", line 91, in __call__
    num_documents, graphs = self.load_and_count_documents(args.filename)
  File "/home/grg/.local/lib/python3.9/site-packages/demes/__main__.py", line 130, in load_and_count_documents
    for graph in graph_generator:
  File "/home/grg/.local/lib/python3.9/site-packages/demes/load_dump.py", line 235, in load_all
    yield demes.Graph.fromdict(data)
  File "/home/grg/.local/lib/python3.9/site-packages/demes/demes.py", line 2108, in fromdict
    check_allowed(pulse_data, allowed_fields_pulse, f"pulse[{i}]")
  File "/home/grg/.local/lib/python3.9/site-packages/demes/demes.py", line 138, in check_allowed
    raise KeyError(
KeyError: "pulse[0]: unexpected field: 'source'. Allowed fields are: ['sources', 'dest', 'time', 'proportions']"
```

To after:

```
$ python -m demes parse /tmp/p.yaml
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/grg/src/demes/demes-python/demes/__main__.py", line 216, in <module>
    cli()
  File "/home/grg/src/demes/demes-python/demes/__main__.py", line 212, in cli
    args.func(args)
  File "/home/grg/src/demes/demes-python/demes/__main__.py", line 91, in __call__
    num_documents, graphs = self.load_and_count_documents(args.filename)
  File "/home/grg/src/demes/demes-python/demes/__main__.py", line 130, in load_and_count_documents
    for graph in graph_generator:
  File "/home/grg/src/demes/demes-python/demes/load_dump.py", line 237, in load_all
    yield demes.Graph.fromdict(data)
  File "/home/grg/src/demes/demes-python/demes/demes.py", line 2108, in fromdict
    check_allowed(pulse_data, allowed_fields_pulse, f"pulse[{i}]")
  File "/home/grg/src/demes/demes-python/demes/demes.py", line 138, in check_allowed
    raise KeyError(
KeyError: "pulse[0]: unexpected field: 'source'. Allowed fields are: ['sources', 'dest', 'time', 'proportions']"
```