### PR TITLE
Create "stable" symlink for the docs.

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,11 +26,12 @@ jobs:
         run: |
           pip install -r requirements/minimal.txt
           pip install -r requirements/docs.txt
+          python -m pip install build packaging
 
       - name: Build package
         run: |
           # Generate the version string which appears in the docs.
-          python setup.py build
+          python -m build --sdist
 
       - name: Build Docs
         run: |
@@ -49,10 +50,26 @@ jobs:
         if: (!github.event.pull_request)
         run: |
           cd demes-docs
-          export DEST=`echo ${GITHUB_REF} | sed -e "s/refs\/heads\///g" |  sed -e "s/refs\/tags\///g"`
-          rm -rf $DEST
-          cp -r ../docs/_build/html $DEST
-          ln -sfT $DEST latest
+          rm -rf ${GITHUB_REF_NAME}
+          cp -r ../docs/_build/html ${GITHUB_REF_NAME}
+          rm -fr latest
+          ln -s ${GITHUB_REF_NAME} latest
+
+      - name: Check if tag is a new stable version
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        run: |
+          if [ -f stable ]; then
+            export STABLE=$(readlink stable)
+          else
+            export STABLE=0
+          fi
+          if python docs/is_new_stable.py ${STABLE} ${GITHUB_REF_NAME}; then
+            # Use for "stable" docs path.
+            echo "new stable is ${GITHUB_REF_NAME}"
+            rm -fr stable
+            ln -s ${GITHUB_REF_NAME} stable
+            echo "STABLE_PATH=stable" >> $GITHUB_ENV
+          fi
 
       - name: Commit and push the docs
         if: (!github.event.pull_request)

--- a/docs/is_new_stable.py
+++ b/docs/is_new_stable.py
@@ -1,0 +1,31 @@
+import sys
+
+import packaging.version
+
+
+def is_new_stable(old_stable, tag):
+    """
+    Return 0 if `tag` should be the new 'stable' docs folder, 1 otherwise.
+    """
+    try:
+        v_t = packaging.version.Version(tag)
+    except packaging.version.InvalidVersion:
+        return 1
+    v_s = packaging.version.Version(old_stable)
+    return 0 if not v_t.is_prerelease and v_t > v_s else 1
+
+
+if __name__ == "__main__":
+    assert is_new_stable("0.2.0", "taggy-mac-tag-tag") != 0
+    assert is_new_stable("0.2.0", "0.1.0") != 0
+    assert is_new_stable("0.2.0", "0.1.0b1") != 0
+    assert is_new_stable("0.2.0", "0.2.0b1") != 0
+    assert is_new_stable("0.2.0", "0.3.0b1") != 0
+    assert is_new_stable("0.2.0", "0.2.1") == 0
+    assert is_new_stable("0.2.0", "0.3.0") == 0
+
+    if len(sys.argv) != 3:
+        print(f"{sys.argv[0]} old_stable tag")
+        exit(2)
+
+    exit(is_new_stable(sys.argv[1], sys.argv[2]))


### PR DESCRIPTION
---
The idea here is that we can link to a 'stable' docs path from external projects (e.g. for the sphinx objects.inv file). I manually created a stable symlink in the current docs repo.