### PR TITLE
Bump jupyter-book

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,15 +40,14 @@ demesdraw.tubes(ooa_graph, ax=ax, log_time=True)
 glue("demesdraw_gutenkunst_ooa", fig, display=False)
 ```
 
-`````{panels}
-:column: container
-````{tabbed} YAML
+`````{tab-set}
+````{tab-item} YAML
 :class-label: pt-0
 ```{literalinclude} ../examples/gutenkunst_ooa.yaml
 :language: yaml
 ```
 ````
-````{tabbed} Drawing
+````{tab-item} Drawing
 :class-label: pt-0
 ```{glue:} demesdraw_gutenkunst_ooa
 ```

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,5 @@
 demesdraw==0.3.0
-jupyter-book==0.12.3
+jupyter-book==0.13.1
 sphinx==4.5.0
 sphinx_issues==3.0.1
 sphinxcontrib-programoutput==0.17


### PR DESCRIPTION
Replace sphinx-panel with sphinx-design, which was removed in
jupyter-book 0.13.0