### PR TITLE
Renaming demes within Graph object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 dist/
 demes.egg-info
 .python-version
+htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ demes/_version.py
 build/
 dist/
 demes.egg-info
+.python-version

--- a/demes/demes.py
+++ b/demes/demes.py
@@ -1997,24 +1997,30 @@ class Graph:
         graph.generation_time = 1
         return graph
 
-    def rename_demes(self, deme_dict={}):
+    def rename_demes(self, rename: MutableMapping[str, str]) -> Graph:
         """
-        Rename demes according to a dictionary
+        Rename demes according to a dictionary.
+
+        :param dict rename:
+            A dictionary with deme names and new names.
+        :return:
+            A demographic model with renamed demes.
+        :rtype: Graph
         """
         graph = copy.deepcopy(self)
-        if not isinstance(deme_dict, dict):
-            raise TypeError("name dict")
-        for k, v in deme_dict.items():
+        if not isinstance(rename, MutableMapping):
+            raise TypeError("rename_dict is not a dictionary")
+        for k, v in rename.items():
             for c in graph.demes:
                 if c.name == k:
-                    c.name = (v,)
+                    c.name = v
                 if c.ancestors is not []:
                     c.ancestors = list(map(lambda x: x.replace(k, v), c.ancestors))
             for m in graph.migrations:
                 if m.source == k:
                     m.source = v
                 if m.dest == k:
-                    m.dest = (v,)
+                    m.dest = v
         return graph
 
     @classmethod

--- a/demes/demes.py
+++ b/demes/demes.py
@@ -1997,6 +1997,26 @@ class Graph:
         graph.generation_time = 1
         return graph
 
+    def rename_demes(self, deme_dict={}):
+        """
+        Rename demes according to a dictionary
+        """
+        graph = copy.deepcopy(self)
+        if not isinstance(deme_dict, dict):
+            raise TypeError("name dict")
+        for k, v in deme_dict.items():
+            for c in graph.demes:
+                if c.name == k:
+                    c.name = (v,)
+                if c.ancestors is not []:
+                    c.ancestors = list(map(lambda x: x.replace(k, v), c.ancestors))
+            for m in graph.migrations:
+                if m.source == k:
+                    m.source = v
+                if m.dest == k:
+                    m.dest = (v,)
+        return graph
+
     @classmethod
     def fromdict(cls, data: MutableMapping[str, Any]) -> Graph:
         """

--- a/demes/demes.py
+++ b/demes/demes.py
@@ -2013,10 +2013,7 @@ class Graph:
         for deme in graph.demes:
             if deme.name in names:
                 deme.name = names[deme.name]
-                deme.ancestors = [
-                    names[ancestor] if ancestor in names else ancestor
-                    for ancestor in deme.ancestors
-                ]
+            deme.ancestors = [names[a] if a in names else a for a in deme.ancestors]
         for migration in graph.migrations:
             if migration.source in names:
                 migration.source = names[migration.source]

--- a/demes/demes.py
+++ b/demes/demes.py
@@ -1997,30 +1997,34 @@ class Graph:
         graph.generation_time = 1
         return graph
 
-    def rename_demes(self, rename: MutableMapping[str, str]) -> Graph:
+    def rename_demes(self, names: MutableMapping[str, str]) -> Graph:
         """
         Rename demes according to a dictionary.
 
-        :param dict rename:
+        :param dict names:
             A dictionary with deme names and new names.
         :return:
             A demographic model with renamed demes.
         :rtype: Graph
         """
         graph = copy.deepcopy(self)
-        if not isinstance(rename, MutableMapping):
-            raise TypeError("rename_dict is not a dictionary")
-        for k, v in rename.items():
-            for c in graph.demes:
-                if c.name == k:
-                    c.name = v
-                if c.ancestors is not []:
-                    c.ancestors = list(map(lambda x: x.replace(k, v), c.ancestors))
-            for m in graph.migrations:
-                if m.source == k:
-                    m.source = v
-                if m.dest == k:
-                    m.dest = v
+        if not isinstance(names, MutableMapping):
+            raise ValueError("names is not a mapping!")
+        for deme in graph.demes:
+            if deme.name not in names:
+                names[deme.name] = deme.name
+        for deme in graph.demes:
+            deme.name = names[deme.name]
+            deme.ancestors = [names[ancestor] for ancestor in deme.ancestors]
+        for migration in graph.migrations:
+            migration.source = names[migration.source]
+            migration.dest = names[migration.dest]
+        for pulse in graph.pulses:
+            pulse.sources = [names[s] for s in pulse.sources]
+            pulse.dest = names[pulse.dest]
+        for k, deme in list(graph._deme_map.items()):
+            del graph._deme_map[k]
+            graph._deme_map[names[k]] = deme
         return graph
 
     @classmethod

--- a/demes/ms.py
+++ b/demes/ms.py
@@ -6,7 +6,7 @@ import logging
 import sys
 import operator
 import itertools
-from typing import Any, List, MutableMapping, Set, Tuple
+from typing import Any, List, Mapping, Set, Tuple
 
 import attr
 
@@ -821,9 +821,7 @@ def build_graph(args, N0: float) -> demes.Graph:
     return graph
 
 
-def remap_deme_names(
-    graph: demes.Graph, names: MutableMapping[str, str]
-) -> demes.Graph:
+def remap_deme_names(graph: demes.Graph, names: Mapping[str, str]) -> demes.Graph:
     assert sorted(names.keys()) == sorted(deme.name for deme in graph.demes)
     graph = graph.rename_demes(names)
     return graph

--- a/demes/ms.py
+++ b/demes/ms.py
@@ -6,7 +6,7 @@ import logging
 import sys
 import operator
 import itertools
-from typing import Any, List, Mapping, Set, Tuple
+from typing import Any, List, MutableMapping, Set, Tuple
 
 import attr
 
@@ -821,21 +821,11 @@ def build_graph(args, N0: float) -> demes.Graph:
     return graph
 
 
-def remap_deme_names(graph: demes.Graph, names: Mapping[str, str]) -> demes.Graph:
+def remap_deme_names(
+    graph: demes.Graph, names: MutableMapping[str, str]
+) -> demes.Graph:
     assert sorted(names.keys()) == sorted(deme.name for deme in graph.demes)
-    graph = copy.deepcopy(graph)
-    for deme in graph.demes:
-        deme.name = names[deme.name]
-        deme.ancestors = [names[ancestor] for ancestor in deme.ancestors]
-    for migration in graph.migrations:
-        migration.source = names[migration.source]
-        migration.dest = names[migration.dest]
-    for pulse in graph.pulses:
-        pulse.sources = [names[s] for s in pulse.sources]
-        pulse.dest = names[pulse.dest]
-    for k, deme in list(graph._deme_map.items()):
-        del graph._deme_map[k]
-        graph._deme_map[names[k]] = deme
+    graph = graph.rename_demes(names)
     return graph
 
 

--- a/tests/test_demes.py
+++ b/tests/test_demes.py
@@ -1877,6 +1877,14 @@ class TestGraph:
         with pytest.raises(ValueError, match="generation_time!=1"):
             b.resolve()
 
+    @pytest.mark.parametrize("graph", tests.example_graphs())
+    def test_rename_demes(self, graph):
+        rev_graph = graph.rename_demes(names={})
+        graph.assert_close(rev_graph)
+        for b in [[], set(), "X", 1, 1.0]:
+            with pytest.raises(ValueError, match="names is not a mapping!"):
+                graph.rename_demes(names=b)
+
     def test_isclose(self):
         b1 = Builder(description="test", time_units="generations")
         b2 = copy.deepcopy(b1)

--- a/tests/test_demes.py
+++ b/tests/test_demes.py
@@ -1882,8 +1882,20 @@ class TestGraph:
         rev_graph = graph.rename_demes(names={})
         graph.assert_close(rev_graph)
         for b in [[], set(), "X", 1, 1.0]:
-            with pytest.raises(ValueError, match="names is not a mapping!"):
+            with pytest.raises(TypeError, match="names is not a dictionary"):
                 graph.rename_demes(names=b)
+        # 1. Rename all of the demes at once ...
+        name_dict = {d.name: f"{d.name}X" for d in graph.demes}
+        rev_graph = graph.rename_demes(names=name_dict)
+        deme_names = [d.name for d in rev_graph.demes]
+        for _, v in name_dict.items():
+            assert v in deme_names
+        # 2. Rename a single deme
+        name_dict_small = {graph.demes[0].name: f"{graph.demes[0].name}Y"}
+        rev_graph = graph.rename_demes(names=name_dict_small)
+        deme_names = [d.name for d in rev_graph.demes]
+        for _, v in name_dict_small.items():
+            assert v in deme_names
 
     def test_isclose(self):
         b1 = Builder(description="test", time_units="generations")


### PR DESCRIPTION
I encountered a need for this feature when looking to develop a `snakemake` workflow that expected specific deme labels for post-processing of simulations. The method is fairly straightforward and implements the type-checks. I will update the tests for this as well if it is a useful feature for others to have or if alternative spec-checks should be performed. 