### PR TITLE
fix dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "monthly"
 


### PR DESCRIPTION
Fixed following advice given by executing the following command:

```sh
npx @bugron/validate-dependabot-yaml@latest .github/dependabot.yml
```

See [here](https://www.npmjs.com/package/@bugron/validate-dependabot-yaml) for more about that command.

See #597